### PR TITLE
Set Language Addition whenHears

### DIFF
--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -28,14 +28,14 @@ class PublicStream extends BaseStream
      *
      * @return $this
      */
-    public function whenHears($listenFor, callable $whenHears, $lang = false)
+    public function whenHears($listenFor, callable $whenHears)
     {
         if (! is_array($listenFor)) {
             $listenFor = [$listenFor];
         }
 
         $this->stream->setTrack($listenFor);
-        $this->stream->setLang($lang);
+
         $this->stream->performOnStreamActivity($whenHears);
 
         return $this;
@@ -56,6 +56,18 @@ class PublicStream extends BaseStream
         $this->stream->setFollow($twitterUserIds);
 
         $this->stream->performOnStreamActivity($whenTweets);
+
+        return $this;
+    }
+    /**
+     * @param string $lang
+     * Restricts tweets to the given language, given by an ISO 639-1 code (http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+     *
+     * @return $this
+     */
+    public function setLocale($lang)
+    {
+        $this->stream->setLang($lang);
 
         return $this;
     }

--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -27,14 +27,16 @@ class PublicStream extends BaseStream
      *
      * @return $this
      */
-    public function whenHears($listenFor, callable $whenHears)
+    public function whenHears($listenFor, callable $whenHears, $lang = false)
     {
         if (! is_array($listenFor)) {
             $listenFor = [$listenFor];
         }
 
         $this->stream->setTrack($listenFor);
-
+        
+        $this->stream->setLang($lang);
+        
         $this->stream->performOnStreamActivity($whenHears);
 
         return $this;

--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -59,6 +59,7 @@ class PublicStream extends BaseStream
 
         return $this;
     }
+    
     /**
      * @param string $lang
      * Restricts tweets to the given language, given by an ISO 639-1 code (http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).

--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -24,6 +24,7 @@ class PublicStream extends BaseStream
     /**
      * @param string|array $listenFor
      * @param callable $whenHears
+     * @param string $lang
      *
      * @return $this
      */
@@ -34,9 +35,7 @@ class PublicStream extends BaseStream
         }
 
         $this->stream->setTrack($listenFor);
-        
         $this->stream->setLang($lang);
-        
         $this->stream->performOnStreamActivity($whenHears);
 
         return $this;


### PR DESCRIPTION
A third optional parameter for the whenHears function, allowing a user
to specify a ISO code from
https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes which is
attributed on Phirehose documentation

Hope this is ok.