### PR TITLE
can stop listening

### DIFF
--- a/src/PhirehoseWrapper.php
+++ b/src/PhirehoseWrapper.php
@@ -49,4 +49,9 @@ class PhirehoseWrapper extends OauthPhirehose
     {
         $this->consume();
     }
+
+    public function stopListening()
+    {
+        $this->disconnect();
+    }
 }


### PR DESCRIPTION
Phirehose class has a disconnect method.
This would allow us to save a reference of the stream and close it later.

This feature is requested in: https://github.com/spatie/laravel-twitter-streaming-api/issues/8