### PR TITLE
Make it possible to track tweets based on location(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Currently, this package works with the public stream and the user stream. Both t
 
 ### The public stream
 
-The public stream can be used to listen for specific words that are being tweeted or to follow one or more users tweets.
+The public stream can be used to listen for specific words that are being tweeted, receive Tweets that are being sent from specific locations or to follow one or more users tweets.
+
+#### Listen for Tweets containing specific words
 
 The first parameter of `whenHears` must be a string or an array containing the word or words you want to listen for. The second parameter should be a callable that will be executed when one of your words is used on Twitter.
 
@@ -72,7 +74,44 @@ PublicStream::create(
 })->startListening();
 ```
 
-The first parameter of `whenTweets` must be a string or an array containing the Twitter user ID or ID's you wish to follow. The second parameter should be a callable that will be executed when one of your followed users tweets.  Only public information relating to the Twitter user will be available.
+#### Listen for Tweets from specific locations
+
+The first parameter of `whenFrom` must be an array containing one or more bounding boxes, each as an array of 4 element lon/lat pairs (looking like `[<south-west point longitude>, <south-west point latitude>, <north-east point longitude>,  <north-east point latitude>]`). The second parameter should be a callable that will be executed when a Tweet from one of your tracked locations is being sent.
+
+**Track all tweets from San Francisco or New York:**
+
+```php
+PublicStream::create(
+    $accessToken,
+    $accessTokenSecret,
+    $consumerKey,
+    $consumerSecret
+)->whenFrom([
+    [-122.75, 36.8, -121.75, 37.8], // San Francisco
+    [-74, 40, -73, 41],             // New York
+], function(array $tweet) {
+        echo "{$tweet['user']['screen_name']} just tweeted {$tweet['text']} from SF or NYC";
+})->startListening();
+```
+
+**Track all tweets with a location (from all over the world):**
+
+```php
+PublicStream::create(
+    $accessToken,
+    $accessTokenSecret,
+    $consumerKey,
+    $consumerSecret
+)->whenFrom([
+        [-180, -90, 180, 90] // Whole world
+], function(array $tweet) {
+    echo "{$tweet['user']['screen_name']} just tweeted {$tweet['text']} with a location attached";
+})->startListening();
+```
+
+#### Listen for Tweets from specific users
+
+The first parameter of `whenTweets` must be a string or an array containing the Twitter user ID or IDs you wish to follow. The second parameter should be a callable that will be executed when one of your followed users tweets. Only public information relating to the Twitter user will be available.
 
 ```php
 PublicStream::create(

--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -42,6 +42,37 @@ class PublicStream extends BaseStream
     }
 
     /**
+     * Specify a set of bounding boxes to track as an array containing one or
+     * more 4 element lon/lat pairs denoting `[<south-west point longitude>,
+     * <south-west point latitude>, <north-east point longitude>,
+     * <north-east point latitude>]`. Only tweets that are both created using
+     * the Geotagging API and are placed from within one of the tracked bounding
+     * boxes will be included in the stream. The user's location field is not
+     * used to filter tweets.
+     *
+     * **Example:**
+     *     PublicStream::create($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret)
+     *         ->whenFrom([
+     *             [-122.75, 36.8, -121.75, 37.8], // San Francisco
+     *             [-74, 40, -73, 41],             // New York
+     *         ], function(array $tweet) {
+     *             echo "{$tweet['user']['screen_name']} just tweeted {$tweet['text']} from SF or NYC";
+     *         })->startListening();
+     *
+     * @param array    $boundingBoxes
+     * @param callable $whenFrom
+     * @return $this
+     */
+    public function whenFrom(array $boundingBoxes, callable $whenFrom)
+    {
+        $this->stream->setLocations($boundingBoxes);
+
+        $this->stream->performOnStreamActivity($whenFrom);
+
+        return $this;
+    }
+
+    /**
      * @param string|array $twitterUserIds
      * @param callable $whenTweets
      *


### PR DESCRIPTION
This adds a wrapper around `Phirehose::setLocations($boundingBoxes)` called `PublicStream::whenFrom($boundingBoxes, $callback)`.

This allows you to track Tweets by location filtered by one or more bounding boxes.

**Track all tweets from San Francisco or New York:**

```php
PublicStream::create($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret)
    ->whenFrom([
        [-122.75, 36.8, -121.75, 37.8], // San Francisco
        [-74, 40, -73, 41],             // New York
    ], function(array $tweet) {
        echo "{$tweet['user']['screen_name']} just tweeted {$tweet['text']} from SF or NYC";
    })->startListening();
```

**Track all tweets with a location (from all over the world):**
```php
PublicStream::create($accessToken, $accessTokenSecret, $consumerKey, $consumerSecret)
    ->whenFrom([
        [-180, -90, 180, 90] // Whole world
    ], function(array $tweet) {
        echo "{$tweet['user']['screen_name']} just tweeted {$tweet['text']} with a location attached";
    })->startListening();
```