### PR TITLE
Bump redwebcreation/laravel-streaming-api to ^0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "redwebcreation/twitter-stream-api": "^0.2"
+        "redwebcreation/twitter-stream-api": "^0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
This will be the last minor version before 1.0.0 (v1 will contain integration tests without mocking). It is really important to update to this version as it fixes a couple of weird bugs and improves error handling a lot.

We might need to release a patch version. 