### PR TITLE
Implement PHP 8.4-specific deprecation

### DIFF
--- a/src/PublicStream.php
+++ b/src/PublicStream.php
@@ -64,7 +64,7 @@ class PublicStream
         return $this;
     }
 
-    public function startListening(Sets $sets = null): void
+    public function startListening(?Sets $sets = null): void
     {
         // Delete old rules
         Rule::deleteBulk(...Rule::all());

--- a/src/UserStream.php
+++ b/src/UserStream.php
@@ -32,7 +32,7 @@ class UserStream
         return $this;
     }
 
-    public function startListening(Sets $sets = null): void
+    public function startListening(?Sets $sets = null): void
     {
         // Delete old rules
         Rule::deleteBulk(...Rule::all());


### PR DESCRIPTION
As my title said, since PHP 8.4, implicitly marking a parameter as nullable is deprecated.